### PR TITLE
improvement + fix: mooshroom cow calculator

### DIFF
--- a/src/app/calculator/farming-fortune/farming-fortune.component.html
+++ b/src/app/calculator/farming-fortune/farming-fortune.component.html
@@ -49,6 +49,10 @@
             with Elephant, you still get more money per hour with Mooshroom
             because of all the extra mushroom drops.
           </p>
+          <p>
+            Additionally, if you are farming mushrooms, Mooshroom cow is
+            <strong>always</strong> better
+          </p>
           <p>Any other improvements or suggestions are welcome.</p>
         </p-accordion-content>
       </p-accordion-panel>

--- a/src/app/calculator/farming-fortune/farming-fortune.component.ts
+++ b/src/app/calculator/farming-fortune/farming-fortune.component.ts
@@ -217,7 +217,7 @@ export class FarmingFortuneComponent {
   // region Pets Level Slider
   mcowLevel = signal(1);
   mcowFortune = computed(() => (
-    this.mcowLevel() + 10 + round(this.totalStrSig() / (40 - 0.2 * this.mcowLevel())) * 0.7
+    this.mcowLevel() + 10 + Math.floor((this.totalStrSig() / (40 - 0.2 * this.mcowLevel())) * 0.7)
   ))
 
   eleLevel = signal(1);

--- a/src/app/calculator/farming-fortune/farming-fortune.component.ts
+++ b/src/app/calculator/farming-fortune/farming-fortune.component.ts
@@ -231,7 +231,7 @@ export class FarmingFortuneComponent {
     } else if (ele > mcow) {
       return 'ele';
     }
-    return null;
+    return "mcow";
   })
   // endregion
   protected readonly formatNum = formatDecimalNoTrailingZero;


### PR DESCRIPTION
adds extra note about mooshroom cow being better

fixes incorrect fortune calculation

defaults to mooshroom cow if both have the same fortune since its better for money