### PR TITLE
Fix: Remove dae axe note

### DIFF
--- a/src/app/calculator/farming-fortune/farming-fortune.component.html
+++ b/src/app/calculator/farming-fortune/farming-fortune.component.html
@@ -24,7 +24,6 @@
               boosts like Gravity Talisman or Weird Tuba.
             </li>
             <li>You are either using Elephant or Mooshroom Cow pet with the same pet item on both.</li>
-            <li>You are using dedicated farming tools instead of Daedalus Axe.</li>
             <li>You are using Forceful power with
               <sb-str/>
               Tuning.


### PR DESCRIPTION
weapons cant break crops anymore as of like 4 months ago

probably shouldve had this in my other pr but i forgor